### PR TITLE
Fix wrong function call in bonus I tutorial

### DIFF
--- a/docs/tutorial/bonus_I.md
+++ b/docs/tutorial/bonus_I.md
@@ -265,7 +265,7 @@ class Type implements EventEngineDescription
      */
     public static function describe(EventEngine $eventEngine): void
     {
-        $eventEngine->registerType(Aggregate::BUILDING, Building\State::__schema());
+        $eventEngine->registerType(Aggregate::BUILDING, self::building());
 
         $eventEngine->registerType(self::USER_BUILDING, self::userBuilding()); //<-- type registration
     }


### PR DESCRIPTION
Came across an error while working through the bonus I part of the event engine tutorial. The `__schema` function does not exist in  
the `Building\State` class and was therefore replaced. 

If you want to merge it, could you please label this request as 'hacktoberfest-accepted'?